### PR TITLE
made kazam work without main window open (indicator only mode)

### DIFF
--- a/kazam/app.py
+++ b/kazam/app.py
@@ -273,9 +273,9 @@ class KazamApp(GObject.GObject):
         if prefs.sound:
             prefs.get_audio_sources()
 
-        if not prefs.silent:
-            self.window.show_all()
-        else:
+        #if not prefs.silent:
+        #    self.window.show_all()
+        #else:
             logger.info("""Starting in silent mode:\n"""
                         """  SUPER-CTRL-W to toggle main window.\n"""
                         """  SUPER-CTRL-R to start recording.\n"""
@@ -535,6 +535,7 @@ class KazamApp(GObject.GObject):
             self.window.hide()
 
     def cb_close_clicked(self, indicator):
+        logger.debug('cb_close_clicked')
         (prefs.main_x, prefs.main_y) = self.window.get_position()
         self.window.hide()
 
@@ -542,7 +543,9 @@ class KazamApp(GObject.GObject):
         AboutDialog(self.icons)
 
     def cb_delete_event(self, widget, user_data):
-        self.cb_quit_request(None)
+        logger.debug(widget)
+        logger.debug('cb_delete_event')
+        #self.cb_quit_request(None)
 
     def cb_start_request(self, widget):
         logger.debug("Start recording selected.")

--- a/kazam/frontend/indicator.py
+++ b/kazam/frontend/indicator.py
@@ -65,6 +65,12 @@ class KazamSuperIndicator(GObject.GObject):
 
         self.menu = Gtk.Menu()
 
+        self.menuitem_settings = Gtk.MenuItem(_("Settings"))
+        self.menuitem_settings.set_sensitive(True)
+        self.menuitem_settings.connect("activate", self.on_menuitem_settings_activate)
+
+        self.menuitem_separator1 = Gtk.SeparatorMenuItem()
+
         self.menuitem_start = Gtk.MenuItem(_("Start recording"))
         self.menuitem_start.set_sensitive(True)
         self.menuitem_start.connect("activate", self.on_menuitem_start_activate)
@@ -77,15 +83,17 @@ class KazamSuperIndicator(GObject.GObject):
         self.menuitem_finish.set_sensitive(False)
         self.menuitem_finish.connect("activate", self.on_menuitem_finish_activate)
 
-        self.menuitem_separator = Gtk.SeparatorMenuItem()
+        self.menuitem_separator2 = Gtk.SeparatorMenuItem()
 
         self.menuitem_quit = Gtk.MenuItem(_("Quit"))
         self.menuitem_quit.connect("activate", self.on_menuitem_quit_activate)
 
+        self.menu.append(self.menuitem_settings)
+        self.menu.append(self.menuitem_separator1)
         self.menu.append(self.menuitem_start)
         self.menu.append(self.menuitem_pause)
         self.menu.append(self.menuitem_finish)
-        self.menu.append(self.menuitem_separator)
+        self.menu.append(self.menuitem_separator2)
         self.menu.append(self.menuitem_quit)
 
         self.menu.show_all()
@@ -131,6 +139,10 @@ class KazamSuperIndicator(GObject.GObject):
     def on_menuitem_start_activate(self, menuitem):
         self.recording = True
         self.emit("indicator-start-request")
+
+    def on_menuitem_settings_activate(self, menuitem):
+        logger.debug('on_menuitem_settings_activate')
+        self.emit('indicator-show-request')
 
     def on_menuitem_finish_activate(self, menuitem):
         self.recording = False


### PR DESCRIPTION
It bothers me a lot that I cannot keep kazam running without the main window open. This pull request keeps kazam running (indicator still visible) when the main window is closed