### PR TITLE
Fix loading full localization

### DIFF
--- a/kazam/app.py
+++ b/kazam/app.py
@@ -824,8 +824,11 @@ class KazamApp(GObject.GObject):
     def setup_translations(self):
         gettext.bindtextdomain("kazam", "/usr/share/locale")
         gettext.textdomain("kazam")
+        locale.bindtextdomain("kazam", "/usr/share/locale")
+        locale.textdomain("kazam")
+        currentLocale = locale.getlocale()
         try:
-            locale.setlocale(locale.LC_ALL, "")
+            locale.setlocale(locale.LC_ALL, currentLocale)
         except Exception as e:
             logger.exception("EXCEPTION: Setlocale failed, no language support.")
 


### PR DESCRIPTION
This patch fixes setting the locale of Kazam's UI.
Without it, Kazam 1.4.5 does not use localizations and is in English on systems with any locale.

Screenshots before and after:
![image](https://user-images.githubusercontent.com/15802528/58752279-02a7a900-84b5-11e9-93d5-50d291d53ca7.png)
