### PR TITLE
disable sound if pulseaudio server is not reachable

### DIFF
--- a/kazam/app.py
+++ b/kazam/app.py
@@ -116,8 +116,12 @@ class KazamApp(GObject.GObject):
         self.last_mode = None
 
         if prefs.sound:
-            prefs.pa_q = pulseaudio_q()
-            prefs.pa_q.start()
+            try:
+                prefs.pa_q = pulseaudio_q()
+                prefs.pa_q.start()
+            except:
+                logger.warning("Pulse Audio Failed to load. Sound recording disabled.")
+                prefs.sound = False
 
         self.mainmenu = MainMenu()
 


### PR DESCRIPTION
In my configuration with no installed pulse audio server, the following import triggered no exception:

(app.py ~ line 90)
```
        if prefs.sound:
            try:
                from kazam.pulseaudio.pulseaudio import pulseaudio_q
                prefs.sound = True
            except:
                logger.warning("Pulse Audio Failed to load. Sound recording disabled.")
                prefs.sound = False

```

but the connection to the sound server failed here:

(app.py ~ line 120)

```
        if prefs.sound:
            prefs.pa_q = pulseaudio_q()
            prefs.pa_q.start()
```

Solved this by putting above lines in a try-except block and disabled sound on exception. works!
