### PR TITLE
get linux distro with distro package

### DIFF
--- a/bin/kazam
+++ b/bin/kazam
@@ -71,8 +71,8 @@ if __name__ == "__main__":
         datadir = curpath.split('bin/')[0] + "share/kazam/"
 
     try:
-        import platform
-        dist = platform.linux_distribution()
+        import distro
+        dist = distro.linux_distribution()
     except:
         # Fallback to the almighty Ubuntu 12.10 ;)
         dist = ('Ubuntu', '12.10', 'quantal')


### PR DESCRIPTION
`linux_distribution()` has been removed from the `platform` package in python 3.8
this confirms it: https://docs.python.org/2/library/platform.html#module-platform

i can't run kazam on my machine (arch linux) and that may be the reason