### PR TITLE
Be able to record whole screen (rather than top left 1/4) on double res screens

### DIFF
--- a/kazam/backend/prefs.py
+++ b/kazam/backend/prefs.py
@@ -314,15 +314,18 @@ class hw:
 
             for i in range(self.default_screen.get_n_monitors()):
                 rect = self.default_screen.get_monitor_geometry(i)
-                self.logger.debug("  Monitor {0} - X: {1}, Y: {2}, W: {3}, H: {4}".format(i,
-                                                                                          rect.x,
-                                                                                          rect.y,
-                                                                                          rect.width,
-                                                                                          rect.height))
+                scale = self.default_screen.get_monitor_scale_factor(i)
+                self.logger.debug("  Monitor {0} - X: {1}, Y: {2}, W: {3}, H: {4}, S: {5}".format(i,
+                                                                                                  rect.x,
+                                                                                                  rect.y,
+                                                                                                  rect.width,
+                                                                                                  rect.height,
+                                                                                                  scale))
                 self.screens.append({"x": rect.x,
                                      "y": rect.y,
                                      "width": rect.width,
-                                     "height": rect.height})
+                                     "height": rect.height,
+                                     "scale": scale})
 
             if self.default_screen.get_n_monitors() > 1:
                 self.combined_screen = {"x": 0, "y": 0,


### PR DESCRIPTION
Based on patchfile found here: https://bugs.launchpad.net/kazam/+bug/1283424

I know `kazam` hasn't been updated in 2 years but it would be great to get this in to make it usable on modern displays.