### PR TITLE
Update readme with ubuntu 23 finish recording workaround

### DIFF
--- a/README
+++ b/README
@@ -38,6 +38,13 @@ $ sudo add-apt-repository ppa:kazam-team/stable-series
 $ sudo apt-get update
 $ sudo apt-get install kazam
 
+If you have problems on Ubuntu 23 with stopping the recording (menu is grey and not selectable, and keyboard shortcut not working), install the following packages:
+```
+$ sudo apt install python3-xlib python-gi-dev python3-cairo-dev
+```
+Keyboard shortcuts should work after this:
+finish recording = "Windows logo" + "Control" + "f"
+
 For distribution independent installation you will have to get the latest
 tarball release from Launchpad:
 


### PR DESCRIPTION
What's in this PR?
- update readme with workaround for ubuntu 23 finish recording issue (raised in issue 85)

Reasoning
- ubuntu 23 has issues stopping recording as menu is grey and not selectable and keyboard shortcut doesn't work consistently -> kazam not usable
- there is a simple workaround by installing python packages which allows the finish recording shortcut to work well -> kazam usable again
-  mention this in readme for ubuntu 23 users who might run into this issue